### PR TITLE
Allow `return await`

### DIFF
--- a/base/tslint.json
+++ b/base/tslint.json
@@ -38,7 +38,8 @@
         "trace"
       ]
     },
-    "await-promise": [true, "Bluebird", "Thenable"]
+    "await-promise": [true, "Bluebird", "Thenable"],
+    "no-return-await": false
   }
 }
 


### PR DESCRIPTION
`return await <promise>` and `return <promise>`  behave different in case of error in promise. 
See more for ref https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function